### PR TITLE
Fix OUTPUT_DIR reference

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,6 +14,10 @@ if getattr(sys, 'frozen', False):
 else:
     BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
+# === 📂 輸出資料夾 ===
+# demo.py 會將產生的圖片輸出到此資料夾
+OUTPUT_DIR = os.path.join(BASE_DIR, "demo_output")
+
 # ==============================
 # 🔤 字體與輸出大小設定
 # ==============================


### PR DESCRIPTION
## Summary
- add missing OUTPUT_DIR constant in `config.py`

## Testing
- `python -m py_compile demo.py config.py builder.py draw_cjk.py draw_hollow.py extractor.py transform.py utils.py safe_char_map.py import_confirmed_previews.py`

------
https://chatgpt.com/codex/tasks/task_e_686cbfc88728832b93559e33e46af41d