### PR TITLE
Fix README instructions and ignore preview outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 demo_output/
+previews/

--- a/README.md
+++ b/README.md
@@ -14,15 +14,23 @@ HandFont is a handwriting-style renderer for Chinese characters, Latin letters a
 ```bash
 pip install pillow fonttools
 # 下載本專案
-git clone https://github.com/AustinHongLee/handfont-playground.git
-cd handfont-playground
+git clone https://github.com/AustinHongLee/Make_report_sign_easy.git
+cd Make_report_sign_easy
 ```
 
 ## 快速使用 Quick Start
 ```python
-from handfont.builder import generate_text_image
+from Make_report_sign_easy.builder import generate_text_image
 img = generate_text_image("手寫效果")
 img.save("example.png")
+```
+
+### 執行範例 Running the demo
+在專案根目錄的上層，使用 `python -m` 方式執行模組：
+
+```bash
+python -m Make_report_sign_easy.demo
+python -m Make_report_sign_easy.tools.preview_fonts 李
 ```
 
 ## 字型路由 Font Routing
@@ -37,7 +45,7 @@ img.save("example.png")
 
 ## 專案結構 Project Structure
 ```
-handfont/        # 核心模組
+Make_report_sign_easy/        # 核心模組
 fonts/           # 字型檔案
 previews/        # 產生的字型預覽
 confirm/         # 社群確認的最佳字型


### PR DESCRIPTION
## Summary
- update repo and module names in README
- document running demo via `python -m`
- ignore preview images

## Testing
- `python -m pip install -r requirements.txt`
- `python -m Make_report_sign_easy.demo`
- `python -m Make_report_sign_easy.tools.preview_fonts 1`


------
https://chatgpt.com/codex/tasks/task_e_686cc463d908832bbbc23302c04528e0