### PR TITLE
Fix README name and demo execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
+*.pyc
 demo_output/
 previews/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ✍️ HandFont Playground
+# ✍️ Make Report Sign Easy
 
 > 中文 / English
 

--- a/demo.py
+++ b/demo.py
@@ -8,6 +8,11 @@
 
 import os
 
+if __name__ == "__main__" and __package__ is None:
+    import sys
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    __package__ = "Make_report_sign_easy"
+
 # 以相對路徑匯入模組，方便直接以 `python -m 包名.demo` 執行
 from . import generate_text_image, sanitize_filename_char
 from .config import OUTPUT_DIR


### PR DESCRIPTION
## Summary
- update project title in README
- ignore Python bytecode
- make `demo.py` runnable directly or as module

## Testing
- `pip install -r requirements.txt`
- `python demo.py`
- `python -m Make_report_sign_easy.demo`


------
https://chatgpt.com/codex/tasks/task_e_686ce09643ac832bb85cfccd004a245a