### PR TITLE
Improve demo and preview usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ img.save("example.png")
 使整體效果更接近自然手寫。
 
 ### 執行範例 Running the demo
-在專案根目錄的上層，使用 `python -m` 方式執行模組：
+請在 *專案資料夾的上層* （或於安裝後）使用 `python -m` 執行，
+若在模組資料夾內執行將出現 `ModuleNotFoundError`：
 
 ```bash
-python -m Make_report_sign_easy.demo
+python -m Make_report_sign_easy.demo "自訂文字" -o output_dir
 python -m Make_report_sign_easy.tools.preview_fonts 李
 ```
+`preview_fonts.py` 執行完會告知預覽圖片存放的路徑（預設在 `previews/`）。
 
 ## 字型路由 Font Routing
 在 `font_routes_template.json` 中指定字 → 字體的映射，例如：

--- a/demo.py
+++ b/demo.py
@@ -7,6 +7,7 @@
 """
 
 import os
+import argparse
 
 if __name__ == "__main__" and __package__ is None:
     import sys
@@ -17,26 +18,36 @@ if __name__ == "__main__" and __package__ is None:
 from . import generate_text_image, sanitize_filename_char
 from .config import OUTPUT_DIR
 
-def run_demo():
-    sample_texts = [
+def run_demo(texts, output_dir, font_path=None, size=None):
+    if not texts:
+        texts = [
         "Hello世界",
         "管線XG32-1200A",
         "！請檢查此區",
         "UU00c885759",
-    ]
+        ]
 
-    if not os.path.exists(OUTPUT_DIR):
-        os.makedirs(OUTPUT_DIR)
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
 
-    for text in sample_texts:
-        image = generate_text_image(text)
+    for text in texts:
+        image = generate_text_image(text, font_path=font_path, size=size)
         if image:
             safe_name = ''.join([sanitize_filename_char(c) for c in text])
-            out_path = os.path.join(OUTPUT_DIR, f"demo_{safe_name}.png")
+            out_path = os.path.join(output_dir, f"demo_{safe_name}.png")
             image.save(out_path)
             print(f"✅ 渲染完成：{out_path}")
         else:
             print(f"⚠️ 無法產生圖像：{text}")
 
+def main():
+    parser = argparse.ArgumentParser(description="Render sample texts to images")
+    parser.add_argument("texts", nargs="*", help="Texts to render")
+    parser.add_argument("-o", "--output-dir", default=OUTPUT_DIR, help="Output directory")
+    parser.add_argument("-f", "--font", dest="font_path", help="Custom font path")
+    parser.add_argument("-s", "--size", type=int, help="Image size")
+    args = parser.parse_args()
+    run_demo(args.texts, args.output_dir, args.font_path, args.size)
+
 if __name__ == "__main__":
-    run_demo()
+    main()

--- a/tools/preview_fonts.py
+++ b/tools/preview_fonts.py
@@ -14,6 +14,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 FONT_DIR = os.path.join(BASE_DIR, "..", "fonts")
 OUTPUT_BASE = os.path.join(BASE_DIR, "..", "previews", safe_text)
 os.makedirs(OUTPUT_BASE, exist_ok=True)
+print(f"📂 預覽將輸出至: {OUTPUT_BASE}")
 
 for font_file in os.listdir(FONT_DIR):
     if not font_file.lower().endswith(".ttf"):
@@ -28,7 +29,7 @@ for font_file in os.listdir(FONT_DIR):
                 safe_ch = sanitize_filename_char(ch)
                 output_path = os.path.join(OUTPUT_BASE, f"{safe_ch}_{font_file}.png")
                 img.save(output_path)
-                print(f"✅ 渲染成功：{ch} - {font_file}")
+                print(f"✅ 渲染成功：{ch} - {font_file} -> {output_path}")
             else:
                 print(f"⚠️ 渲染失敗：{ch} - {font_file}")
         except Exception as e:


### PR DESCRIPTION
## Summary
- add CLI options to demo.py so custom text, font and output location can be specified
- show output directory at start of preview_fonts script and print file path when saving
- update README with clearer instructions on running the module and where previews are saved

## Testing
- `python -m py_compile tools/preview_fonts.py demo.py`

------
https://chatgpt.com/codex/tasks/task_e_686e2020d508832b95e8d18285ca0d01