### PR TITLE
Add parameter GUI with JSON overrides

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@
 
 import os
 import sys
+import json
 
 # === 📁 模組根目錄（可相容打包後的 __file__）===
 if getattr(sys, 'frozen', False):
@@ -29,7 +30,6 @@ FONT_PATH = os.path.join(BASE_DIR, 'fonts', 'ChenYuluoyan-2.0-Thin.ttf')
 ROUTER_PATH = os.path.join(BASE_DIR, 'font_routes_template.json')
 
 if os.path.exists(ROUTER_PATH):
-    import json
     with open(ROUTER_PATH, 'r', encoding='utf-8') as f:
         FONT_ROUTER = json.load(f)
 else:
@@ -121,6 +121,14 @@ PARTIAL_DOT_RADIUS = (1.5, 4)
 # 筆劃線寬（用於線條層）
 # - 建議：1 ~ 3
 LINE_WIDTH = 1
+
+# === 🗃️ 外部參數覆寫 ===
+CUSTOM_CONFIG_PATH = os.path.join(BASE_DIR, "custom_config.json")
+if os.path.exists(CUSTOM_CONFIG_PATH):
+    import json
+    with open(CUSTOM_CONFIG_PATH, "r", encoding="utf-8") as f:
+        user_conf = json.load(f)
+        globals().update(user_conf)
 
 # ============ 🪶 渲染控制參數 ============
 # 是否開啟每個層（可未來擴充用）

--- a/config_gui.py
+++ b/config_gui.py
@@ -1,0 +1,80 @@
+import os
+import json
+import tkinter as tk
+from tkinter import ttk
+from PIL import ImageTk, Image
+
+if __name__ == "__main__" and __package__ is None:
+    import sys
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    __package__ = "Make_report_sign_easy"
+
+from . import builder, config
+
+CUSTOM_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "custom_config.json")
+
+class ConfigGUI(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("HandFont 參數設定")
+        self.params = {
+            "PERTURB": {"var": tk.IntVar(value=config.PERTURB), "min": 0, "max": 20},
+            "PERTURB_JITTER": {"var": tk.IntVar(value=config.PERTURB_JITTER), "min": 0, "max": 5},
+            "SHEAR_ANGLE": {"var": tk.IntVar(value=config.SHEAR_ANGLE), "min": -30, "max": 30},
+            "COLOR_VARIATION": {"var": tk.IntVar(value=config.COLOR_VARIATION), "min": 0, "max": 60},
+            "LINE_WIDTH": {"var": tk.IntVar(value=config.LINE_WIDTH), "min": 1, "max": 5},
+        }
+        self._build_ui()
+        self.update_preview()
+
+    def _build_ui(self):
+        row = 0
+        for name, info in self.params.items():
+            ttk.Label(self, text=name).grid(row=row, column=0, sticky="w", padx=5, pady=2)
+            entry = ttk.Entry(self, textvariable=info["var"], width=6)
+            entry.grid(row=row, column=1, padx=5)
+            scale = ttk.Scale(
+                self,
+                from_=info["min"],
+                to=info["max"],
+                orient=tk.HORIZONTAL,
+                variable=info["var"],
+                command=lambda e: self.update_preview(),
+            )
+            scale.grid(row=row, column=2, sticky="we", padx=5)
+            row += 1
+
+        self.columnconfigure(2, weight=1)
+        self.preview_label = ttk.Label(self)
+        self.preview_label.grid(row=0, column=3, rowspan=row, padx=10, pady=10)
+
+        ttk.Button(self, text="儲存設定", command=self.save_config).grid(
+            row=row, column=0, columnspan=3, pady=10
+        )
+
+    def update_preview(self):
+        for name, info in self.params.items():
+            value = int(info["var"].get())
+            setattr(config, name, value)
+            setattr(builder, name, value)
+        img = builder.generate_text_image("李宗鴻")
+        if img:
+            img.thumbnail((200, 200))
+            self._tk_img = ImageTk.PhotoImage(img)
+            self.preview_label.configure(image=self._tk_img)
+
+    def save_config(self):
+        data = {name: int(info["var"].get()) for name, info in self.params.items()}
+        with open(CUSTOM_CONFIG_PATH, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        print(f"✅ 已儲存 {CUSTOM_CONFIG_PATH}")
+
+
+def main():
+    app = ConfigGUI()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/custom_config.json
+++ b/custom_config.json
@@ -1,0 +1,7 @@
+{
+  "PERTURB": 12,
+  "PERTURB_JITTER": 2,
+  "SHEAR_ANGLE": 20,
+  "COLOR_VARIATION": 20,
+  "LINE_WIDTH": 1
+}


### PR DESCRIPTION
## Summary
- support loading `custom_config.json` to override default settings
- provide `config_gui.py` for adjusting parameters with a Tkinter GUI
- include a sample `custom_config.json`

## Testing
- `pytest -q`
- `python config_gui.py` *(fails: no display name)*

------
https://chatgpt.com/codex/tasks/task_e_686f09c15b28832b9ca940339258d0b8