### PR TITLE
Add adjustable scale/offset for char groups

### DIFF
--- a/config.py
+++ b/config.py
@@ -126,6 +126,17 @@ LINE_WIDTH = 1
 # - 建議：-100 ~ 100
 CHAR_SPACING_OFFSET = 0
 
+# === 字型群組預設調整量 ===
+# 各類字元的縮放倍率與垂直位移，可在 GUI 或 custom_config.json 中覆寫
+DIGIT_SCALE = 0.8
+DIGIT_OFFSET_Y = 0.0
+ALPHA_SCALE = 1.0
+ALPHA_OFFSET_Y = 0.0
+CJK_SCALE = 1.0
+CJK_OFFSET_Y = 0.0
+SPECIAL_SCALE = 1.0
+SPECIAL_OFFSET_Y = 0.0
+
 # === 🗃️ 外部參數覆寫 ===
 CUSTOM_CONFIG_PATH = os.path.join(BASE_DIR, "custom_config.json")
 if os.path.exists(CUSTOM_CONFIG_PATH):
@@ -181,7 +192,9 @@ SPECIAL_RENDER_OVERRIDES = {
 
 # 對數字補充設定（數字通常佔據較大字框）
 for d in '0123456789':
-    SPECIAL_RENDER_OVERRIDES[d] = {'scale': 0.8}
+    SPECIAL_RENDER_OVERRIDES.setdefault(d, {})
+    SPECIAL_RENDER_OVERRIDES[d].setdefault('scale', DIGIT_SCALE)
+    SPECIAL_RENDER_OVERRIDES[d].setdefault('offset_y', DIGIT_OFFSET_Y)
 
 
 # ==============================
@@ -201,6 +214,14 @@ PARAM_INFO = {
     'PARTIAL_DOT_RADIUS': ('斷墨點半徑', '1.5 ~ 6'),
     'LINE_WIDTH': ('線條寬度', '1 ~ 3'),
     'CHAR_SPACING_OFFSET': ('字距調整量', '-100 ~ 100'),
+    'DIGIT_SCALE': ('數字縮放倍率', '0.5 ~ 1.5'),
+    'DIGIT_OFFSET_Y': ('數字垂直位移', '-0.5 ~ 0.5'),
+    'ALPHA_SCALE': ('英文縮放倍率', '0.5 ~ 1.5'),
+    'ALPHA_OFFSET_Y': ('英文垂直位移', '-0.5 ~ 0.5'),
+    'CJK_SCALE': ('中文縮放倍率', '0.5 ~ 1.5'),
+    'CJK_OFFSET_Y': ('中文垂直位移', '-0.5 ~ 0.5'),
+    'SPECIAL_SCALE': ('特殊符縮放', '0.5 ~ 1.5'),
+    'SPECIAL_OFFSET_Y': ('特殊符位移', '-0.5 ~ 0.5'),
     'BLUR_AMOUNT': ('最終高斯模糊量', '1.5 ~ 3'),
     'PARTIAL_DOT_PROBABILITY': ('斷墨點出現機率', '0.0 ~ 1.0'),
 }

--- a/config_gui.py
+++ b/config_gui.py
@@ -18,12 +18,20 @@ class ConfigGUI(tk.Tk):
         super().__init__()
         self.title("HandFont 參數設定")
         self.params = {
-            "PERTURB": {"var": tk.IntVar(value=config.PERTURB), "min": 0, "max": 20},
-            "PERTURB_JITTER": {"var": tk.IntVar(value=config.PERTURB_JITTER), "min": 0, "max": 5},
-            "SHEAR_ANGLE": {"var": tk.IntVar(value=config.SHEAR_ANGLE), "min": -30, "max": 30},
-            "COLOR_VARIATION": {"var": tk.IntVar(value=config.COLOR_VARIATION), "min": 0, "max": 60},
-            "LINE_WIDTH": {"var": tk.IntVar(value=config.LINE_WIDTH), "min": 1, "max": 5},
-            "CHAR_SPACING_OFFSET": {"var": tk.IntVar(value=config.CHAR_SPACING_OFFSET), "min": -100, "max": 100},
+            "PERTURB": {"var": tk.IntVar(value=config.PERTURB), "min": 0, "max": 20, "type": int},
+            "PERTURB_JITTER": {"var": tk.IntVar(value=config.PERTURB_JITTER), "min": 0, "max": 5, "type": int},
+            "SHEAR_ANGLE": {"var": tk.IntVar(value=config.SHEAR_ANGLE), "min": -30, "max": 30, "type": int},
+            "COLOR_VARIATION": {"var": tk.IntVar(value=config.COLOR_VARIATION), "min": 0, "max": 60, "type": int},
+            "LINE_WIDTH": {"var": tk.IntVar(value=config.LINE_WIDTH), "min": 1, "max": 5, "type": int},
+            "CHAR_SPACING_OFFSET": {"var": tk.IntVar(value=config.CHAR_SPACING_OFFSET), "min": -100, "max": 100, "type": int},
+            "DIGIT_SCALE": {"var": tk.DoubleVar(value=config.DIGIT_SCALE), "min": 0.5, "max": 1.5, "type": float},
+            "DIGIT_OFFSET_Y": {"var": tk.DoubleVar(value=config.DIGIT_OFFSET_Y), "min": -0.5, "max": 0.5, "type": float},
+            "ALPHA_SCALE": {"var": tk.DoubleVar(value=config.ALPHA_SCALE), "min": 0.5, "max": 1.5, "type": float},
+            "ALPHA_OFFSET_Y": {"var": tk.DoubleVar(value=config.ALPHA_OFFSET_Y), "min": -0.5, "max": 0.5, "type": float},
+            "CJK_SCALE": {"var": tk.DoubleVar(value=config.CJK_SCALE), "min": 0.5, "max": 1.5, "type": float},
+            "CJK_OFFSET_Y": {"var": tk.DoubleVar(value=config.CJK_OFFSET_Y), "min": -0.5, "max": 0.5, "type": float},
+            "SPECIAL_SCALE": {"var": tk.DoubleVar(value=config.SPECIAL_SCALE), "min": 0.5, "max": 1.5, "type": float},
+            "SPECIAL_OFFSET_Y": {"var": tk.DoubleVar(value=config.SPECIAL_OFFSET_Y), "min": -0.5, "max": 0.5, "type": float},
         }
         self._build_ui()
         self.update_preview()
@@ -56,7 +64,9 @@ class ConfigGUI(tk.Tk):
 
     def update_preview(self):
         for name, info in self.params.items():
-            value = int(info["var"].get())
+            var_value = info["var"].get()
+            cast = info.get("type", float)
+            value = cast(var_value)
             setattr(config, name, value)
             setattr(builder, name, value)
         img = builder.generate_text_image("預覽123ABC!?中文")
@@ -69,7 +79,10 @@ class ConfigGUI(tk.Tk):
             self.preview_label.configure(image=self._tk_img)
 
     def save_config(self):
-        data = {name: int(info["var"].get()) for name, info in self.params.items()}
+        data = {}
+        for name, info in self.params.items():
+            cast = info.get("type", float)
+            data[name] = cast(info["var"].get())
         with open(CUSTOM_CONFIG_PATH, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
         print(f"✅ 已儲存 {CUSTOM_CONFIG_PATH}")

--- a/draw_cjk.py
+++ b/draw_cjk.py
@@ -4,7 +4,11 @@ import random
 from .config import (
     COLOR_BASE, COLOR_VARIATION, ALPHA_RANGE,
     BLOB_SIZE_RANGE, PARTIAL_DOT_RADIUS, LINE_WIDTH,
-    SPECIAL_RENDER_OVERRIDES
+    SPECIAL_RENDER_OVERRIDES,
+    DIGIT_SCALE, DIGIT_OFFSET_Y,
+    ALPHA_SCALE, ALPHA_OFFSET_Y,
+    CJK_SCALE, CJK_OFFSET_Y,
+    SPECIAL_SCALE, SPECIAL_OFFSET_Y,
 )
 
 # 👉 工具
@@ -83,8 +87,29 @@ def render_cjk_char(paths, size=512, current_char=None):
     min_x, max_x = min(all_x), max(all_x)
     min_y, max_y = min(all_y), max(all_y)
 
-    scale_ratio = SPECIAL_RENDER_OVERRIDES.get(current_char, {}).get("scale", 1.0)
-    offset_y_ratio = SPECIAL_RENDER_OVERRIDES.get(current_char, {}).get("offset_y", 0.0)
+    override = SPECIAL_RENDER_OVERRIDES.get(current_char, {})
+    scale_ratio = override.get("scale")
+    offset_y_ratio = override.get("offset_y")
+
+    if scale_ratio is None:
+        if current_char is not None and '\u4e00' <= current_char <= '\u9fff':
+            scale_ratio = CJK_SCALE
+        elif current_char is not None and current_char.isdigit():
+            scale_ratio = DIGIT_SCALE
+        elif current_char is not None and current_char.isalpha():
+            scale_ratio = ALPHA_SCALE
+        else:
+            scale_ratio = SPECIAL_SCALE
+
+    if offset_y_ratio is None:
+        if current_char is not None and '\u4e00' <= current_char <= '\u9fff':
+            offset_y_ratio = CJK_OFFSET_Y
+        elif current_char is not None and current_char.isdigit():
+            offset_y_ratio = DIGIT_OFFSET_Y
+        elif current_char is not None and current_char.isalpha():
+            offset_y_ratio = ALPHA_OFFSET_Y
+        else:
+            offset_y_ratio = SPECIAL_OFFSET_Y
 
     # 檢查分母是否為零
     if max_x == min_x or max_y == min_y:

--- a/draw_hollow.py
+++ b/draw_hollow.py
@@ -4,7 +4,11 @@ import random
 from .config import (
     COLOR_BASE, COLOR_VARIATION, ALPHA_RANGE,
     BLOB_SIZE_RANGE, PARTIAL_DOT_RADIUS, LINE_WIDTH,
-    SPECIAL_RENDER_OVERRIDES
+    SPECIAL_RENDER_OVERRIDES,
+    DIGIT_SCALE, DIGIT_OFFSET_Y,
+    ALPHA_SCALE, ALPHA_OFFSET_Y,
+    CJK_SCALE, CJK_OFFSET_Y,
+    SPECIAL_SCALE, SPECIAL_OFFSET_Y,
 )
 
 # 👉 工具
@@ -103,8 +107,29 @@ def render_hollow_char(paths, size=512, current_char=None):
     min_x, max_x = min(all_x), max(all_x)
     min_y, max_y = min(all_y), max(all_y)
 
-    scale_ratio = SPECIAL_RENDER_OVERRIDES.get(current_char, {}).get("scale", 1.0)
-    offset_y_ratio = SPECIAL_RENDER_OVERRIDES.get(current_char, {}).get("offset_y", 0.0)
+    override = SPECIAL_RENDER_OVERRIDES.get(current_char, {})
+    scale_ratio = override.get("scale")
+    offset_y_ratio = override.get("offset_y")
+
+    if scale_ratio is None:
+        if current_char is not None and '\u4e00' <= current_char <= '\u9fff':
+            scale_ratio = CJK_SCALE
+        elif current_char is not None and current_char.isdigit():
+            scale_ratio = DIGIT_SCALE
+        elif current_char is not None and current_char.isalpha():
+            scale_ratio = ALPHA_SCALE
+        else:
+            scale_ratio = SPECIAL_SCALE
+
+    if offset_y_ratio is None:
+        if current_char is not None and '\u4e00' <= current_char <= '\u9fff':
+            offset_y_ratio = CJK_OFFSET_Y
+        elif current_char is not None and current_char.isdigit():
+            offset_y_ratio = DIGIT_OFFSET_Y
+        elif current_char is not None and current_char.isalpha():
+            offset_y_ratio = ALPHA_OFFSET_Y
+        else:
+            offset_y_ratio = SPECIAL_OFFSET_Y
 
     if max_x == min_x or max_y == min_y:
         scale = 0


### PR DESCRIPTION
## Summary
- add group-level scale/offset parameters to configuration
- allow digits to inherit these defaults
- update drawing functions to fallback to group settings
- extend GUI with sliders for new parameters

## Testing
- `pip install -r requirements.txt`
- `python -m compileall -q config.py builder.py utils.py draw_cjk.py draw_hollow.py config_gui.py`
- `python demo.py '123中文!?' -o /tmp`

------
https://chatgpt.com/codex/tasks/task_e_686f362e24cc832ba0e9ca45ce8af900