### PR TITLE
Fix config GUI preview and digit spacing

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -3,16 +3,7 @@ import os
 import random
 
 # 使用相對路徑引用同一套件內的模組，避免在直接執行時找不到 handfont 套件
-from .config import (
-    IMAGE_SIZE,
-    SPECIAL_RENDER_OVERRIDES,
-    FONT_PATH,
-    FONT_ROUTER,
-    PERTURB,
-    PERTURB_JITTER,
-    SHEAR_ANGLE,
-    SHEAR_JITTER,
-)
+from . import config
 from .extractor import extract_paths
 from .transform import perturb, shear, flip_y
 from .utils import get_spacing, sanitize_filename_char
@@ -26,11 +17,9 @@ HOLLOW_CHARS = "O0ABDPAQRGabdeopqg869"
 
 def generate_text_image(text, font_path=None, size=None, ignore_router=False):
     if font_path is None:
-        from .config import FONT_PATH as DEFAULT_FONT
-        font_path = DEFAULT_FONT
+        font_path = config.FONT_PATH
     if size is None:
-        from .config import IMAGE_SIZE as DEFAULT_SIZE
-        size = DEFAULT_SIZE
+        size = config.IMAGE_SIZE
     """
     給定文字與字體路徑，回傳 PIL.Image。
     此版本包含智慧分派邏輯。
@@ -49,11 +38,11 @@ def generate_text_image(text, font_path=None, size=None, ignore_router=False):
 
             # 通用前置作業：提取路徑和變形
             # 若有特殊指定用字型，就改用該字型
-            font_used = font_path if ignore_router else FONT_ROUTER.get(ch, font_path)
+            font_used = font_path if ignore_router else config.FONT_ROUTER.get(ch, font_path)
             paths = extract_paths(font_used, ch)
             # 依據設定值加入少量隨機變形，模擬手寫差異
-            perturb_amount = PERTURB + random.uniform(-PERTURB_JITTER, PERTURB_JITTER)
-            shear_amount = SHEAR_ANGLE + random.uniform(-SHEAR_JITTER, SHEAR_JITTER)
+            perturb_amount = config.PERTURB + random.uniform(-config.PERTURB_JITTER, config.PERTURB_JITTER)
+            shear_amount = config.SHEAR_ANGLE + random.uniform(-config.SHEAR_JITTER, config.SHEAR_JITTER)
             paths = flip_y(shear(perturb(paths, perturb_amount), shear_amount))
 
             # ⭐ --- 智慧分派邏輯 --- ⭐
@@ -91,8 +80,8 @@ def generate_text_image(text, font_path=None, size=None, ignore_router=False):
 
     return canvas
 
-def save_text_image(text, font_path=FONT_PATH, output_path=None, size=IMAGE_SIZE):
-    img = generate_text_image(text, font_path, size)
+def save_text_image(text, font_path=None, output_path=None, size=None):
+    img = generate_text_image(text, font_path or config.FONT_PATH, size or config.IMAGE_SIZE)
     if img:
         if output_path:
             img.save(output_path)

--- a/draw_hollow.py
+++ b/draw_hollow.py
@@ -1,15 +1,7 @@
 from PIL import Image, ImageDraw, ImageFilter
 import random
 # 相對匯入確保在原始碼路徑下執行時也能找到模組
-from .config import (
-    COLOR_BASE, COLOR_VARIATION, ALPHA_RANGE,
-    BLOB_SIZE_RANGE, PARTIAL_DOT_RADIUS, LINE_WIDTH,
-    SPECIAL_RENDER_OVERRIDES,
-    DIGIT_SCALE, DIGIT_OFFSET_Y,
-    ALPHA_SCALE, ALPHA_OFFSET_Y,
-    CJK_SCALE, CJK_OFFSET_Y,
-    SPECIAL_SCALE, SPECIAL_OFFSET_Y,
-)
+from . import config
 
 # 👉 工具
 def with_alpha(rgb, alpha):
@@ -51,24 +43,23 @@ def draw_solid_fill_layer(paths, size, scale, ox, oy, min_x, min_y, current_char
                 draw.polygon(poly, fill=255)
     
     final_layer = Image.new("RGBA", (size, size), (0, 0, 0, 0))
-    alpha = SPECIAL_RENDER_OVERRIDES.get(current_char, {}).get("alpha", 255)
-    color_layer = Image.new("RGBA", (size, size), varied_color(COLOR_BASE, COLOR_VARIATION, alpha))
+    alpha = config.SPECIAL_RENDER_OVERRIDES.get(current_char, {}).get("alpha", 255)
+    color_layer = Image.new("RGBA", (size, size), varied_color(config.COLOR_BASE, config.COLOR_VARIATION, alpha))
     final_layer.paste(color_layer, mask=mask)
     return final_layer
 
 
 def draw_partial_fill_layer(paths, size, scale, ox, oy, min_x, min_y):
-    from .config import PARTIAL_DOT_PROBABILITY
     layer = Image.new("RGBA", (size, size), (0, 0, 0, 0))
     draw = ImageDraw.Draw(layer)
     for path in paths:
         for (x, y) in path[::max(1, len(path)//6)]:
-            if random.random() < PARTIAL_DOT_PROBABILITY:
+            if random.random() < config.PARTIAL_DOT_PROBABILITY:
                 px = (x - min_x) * scale + ox
                 py = (y - min_y) * scale + oy
-                r = random.uniform(*PARTIAL_DOT_RADIUS)
+                r = random.uniform(*config.PARTIAL_DOT_RADIUS)
                 draw.ellipse((px - r, py - r, px + r, py + r),
-                             fill=varied_color(COLOR_BASE, COLOR_VARIATION, random.randint(*ALPHA_RANGE)))
+                             fill=varied_color(config.COLOR_BASE, config.COLOR_VARIATION, random.randint(*config.ALPHA_RANGE)))
     return layer
 
 
@@ -82,7 +73,7 @@ def draw_stroke_alpha_layer(paths, size, scale, ox, oy, min_x, min_y):
             p1 = ((x1 - min_x) * scale + ox, (y1 - min_y) * scale + oy)
             p2 = ((x2 - min_x) * scale + ox, (y2 - min_y) * scale + oy)
             alpha = int(255 * (1 - abs(i / len(path) - 0.5) * 2))
-            draw.line(p1 + p2, fill=with_alpha(COLOR_BASE, alpha), width=LINE_WIDTH)
+            draw.line(p1 + p2, fill=with_alpha(config.COLOR_BASE, alpha), width=config.LINE_WIDTH)
     return layer
 
 
@@ -94,9 +85,9 @@ def draw_stroke_blob_layer(paths, size, scale, ox, oy, min_x, min_y):
             x, y = path[i]
             px = (x - min_x) * scale + ox
             py = (y - min_y) * scale + oy
-            r = random.randint(*BLOB_SIZE_RANGE)
+            r = random.randint(*config.BLOB_SIZE_RANGE)
             draw.ellipse((px - r, py - r, px + r, py + r),
-                         fill=varied_color(COLOR_BASE, COLOR_VARIATION, random.randint(*ALPHA_RANGE)))
+                         fill=varied_color(config.COLOR_BASE, config.COLOR_VARIATION, random.randint(*config.ALPHA_RANGE)))
     return layer
 
 
@@ -107,29 +98,29 @@ def render_hollow_char(paths, size=512, current_char=None):
     min_x, max_x = min(all_x), max(all_x)
     min_y, max_y = min(all_y), max(all_y)
 
-    override = SPECIAL_RENDER_OVERRIDES.get(current_char, {})
+    override = config.SPECIAL_RENDER_OVERRIDES.get(current_char, {})
     scale_ratio = override.get("scale")
     offset_y_ratio = override.get("offset_y")
 
     if scale_ratio is None:
         if current_char is not None and '\u4e00' <= current_char <= '\u9fff':
-            scale_ratio = CJK_SCALE
+            scale_ratio = config.CJK_SCALE
         elif current_char is not None and current_char.isdigit():
-            scale_ratio = DIGIT_SCALE
+            scale_ratio = config.DIGIT_SCALE
         elif current_char is not None and current_char.isalpha():
-            scale_ratio = ALPHA_SCALE
+            scale_ratio = config.ALPHA_SCALE
         else:
-            scale_ratio = SPECIAL_SCALE
+            scale_ratio = config.SPECIAL_SCALE
 
     if offset_y_ratio is None:
         if current_char is not None and '\u4e00' <= current_char <= '\u9fff':
-            offset_y_ratio = CJK_OFFSET_Y
+            offset_y_ratio = config.CJK_OFFSET_Y
         elif current_char is not None and current_char.isdigit():
-            offset_y_ratio = DIGIT_OFFSET_Y
+            offset_y_ratio = config.DIGIT_OFFSET_Y
         elif current_char is not None and current_char.isalpha():
-            offset_y_ratio = ALPHA_OFFSET_Y
+            offset_y_ratio = config.ALPHA_OFFSET_Y
         else:
-            offset_y_ratio = SPECIAL_OFFSET_Y
+            offset_y_ratio = config.SPECIAL_OFFSET_Y
 
     if max_x == min_x or max_y == min_y:
         scale = 0
@@ -161,5 +152,4 @@ def render_hollow_char(paths, size=512, current_char=None):
         padded.paste(image, ((size - new_size) // 2, int(size * y_offset_ratio)))
         return padded
 
-    from .config import BLUR_AMOUNT
-    return base.filter(ImageFilter.GaussianBlur(BLUR_AMOUNT))
+    return base.filter(ImageFilter.GaussianBlur(config.BLUR_AMOUNT))

--- a/utils.py
+++ b/utils.py
@@ -32,7 +32,9 @@ def get_spacing(ch):
         base = config.SPECIAL_RENDER_OVERRIDES[ch].get("spacing", -5)
     elif '\u4e00' <= ch <= '\u9fff':
         base = 5
-    elif ch.isdigit() or ch.isalpha():
+    elif ch.isdigit():
+        base = -80
+    elif ch.isalpha():
         base = -60
     else:
         base = 10


### PR DESCRIPTION
## Summary
- update rendering modules to read parameters from `config`
- narrow default digit spacing
- ensure builder reads latest config values

## Testing
- `python -m pip install -r requirements.txt`
- `python demo.py`

------
https://chatgpt.com/codex/tasks/task_e_686f59572004832b9b2cbd37207231b7