### PR TITLE
Fix digit preview refresh

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -16,6 +16,9 @@ from .draw_hollow import render_hollow_char
 HOLLOW_CHARS = "O0ABDPAQRGabdeopqg869"
 
 def generate_text_image(text, font_path=None, size=None, ignore_router=False):
+    # 保持數字相關設定最新
+    if hasattr(config, "sync_digit_overrides"):
+        config.sync_digit_overrides()
     if font_path is None:
         font_path = config.FONT_PATH
     if size is None:

--- a/config.py
+++ b/config.py
@@ -196,6 +196,16 @@ for d in '0123456789':
     SPECIAL_RENDER_OVERRIDES[d].setdefault('scale', DIGIT_SCALE)
     SPECIAL_RENDER_OVERRIDES[d].setdefault('offset_y', DIGIT_OFFSET_Y)
 
+# 新增：確保後續修改縮放或位移時可即時套用
+def sync_digit_overrides():
+    """Synchronize digit settings into SPECIAL_RENDER_OVERRIDES."""
+    for d in '0123456789':
+        SPECIAL_RENDER_OVERRIDES.setdefault(d, {})
+        SPECIAL_RENDER_OVERRIDES[d]['scale'] = DIGIT_SCALE
+        SPECIAL_RENDER_OVERRIDES[d]['offset_y'] = DIGIT_OFFSET_Y
+
+sync_digit_overrides()
+
 
 # ==============================
 # 📖 參數說明與安全範圍

--- a/config_gui.py
+++ b/config_gui.py
@@ -69,6 +69,8 @@ class ConfigGUI(tk.Tk):
             value = cast(var_value)
             setattr(config, name, value)
             setattr(builder, name, value)
+        # 更新數字專用設定，避免舊值殘留於 SPECIAL_RENDER_OVERRIDES
+        config.sync_digit_overrides()
         img = builder.generate_text_image("預覽123ABC!?中文")
         if img:
             target_height = 200


### PR DESCRIPTION
## Summary
- refresh digit overrides whenever rendering text

## Testing
- `pip install -r requirements.txt`
- `python demo.py -o /tmp/demo_output`

------
https://chatgpt.com/codex/tasks/task_e_686f6d46a3c4832b812fe664566e2f79