### PR TITLE
Fix space spacing logic

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -33,9 +33,9 @@ def generate_text_image(text, font_path=None, size=None, ignore_router=False):
     for ch in text:
         try:
             if ch == ' ':
-                spacing = get_spacing(ch)
+                spacing = get_spacing(ch, size)
                 # 為了避免拼接問題，空白也產生一個透明圖像
-                images.append(Image.new("RGBA", (int(size * spacing), 1)))
+                images.append(Image.new("RGBA", (spacing, 1)))
                 spacings.append(0)
                 continue
 

--- a/utils.py
+++ b/utils.py
@@ -22,12 +22,14 @@ def sanitize_filename_char(c):
     return f'U{ord(c):04X}' if c in config.SPECIAL_RENDER_OVERRIDES or c in '<>:"/\\|?*' else c
 
 
-def get_spacing(ch):
+def get_spacing(ch, size=None):
     """
-    ✅ 根據不同字元類型取得預設間距
+    ✅ 根據不同字元類型取得預設間距 (單位: 像素)
+
+    For space characters the width is derived from the target font size.
     """
     if ch == ' ':
-        base = 500
+        base = int((size or config.IMAGE_SIZE) * 0.5)
     elif ch in config.SPECIAL_RENDER_OVERRIDES:
         base = config.SPECIAL_RENDER_OVERRIDES[ch].get("spacing", -5)
     elif '\u4e00' <= ch <= '\u9fff':


### PR DESCRIPTION
## Summary
- compute space width in pixels using font size
- keep builder logic consistent for space spacing
- document pixel units for get_spacing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python demo.py "Hello" -o /tmp/test_output`

------
https://chatgpt.com/codex/tasks/task_e_6870815282ac832b9f794422233adeaf