### PR TITLE
Improve font loading performance

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -4,7 +4,7 @@ import random
 
 # 使用相對路徑引用同一套件內的模組，避免在直接執行時找不到 handfont 套件
 from . import config
-from .extractor import extract_paths
+from .extractor import extract_paths, _load_font
 from .transform import perturb, shear, flip_y
 from .utils import get_spacing, sanitize_filename_char
 
@@ -15,7 +15,7 @@ from .draw_hollow import render_hollow_char
 # 2. 定義需要由「空心專家」處理的字元列表
 HOLLOW_CHARS = "O0ABDPAQRGabdeopqg869"
 
-def generate_text_image(text, font_path=None, size=None, ignore_router=False):
+def generate_text_image(text, font_path=None, size=None, ignore_router=False, clear_cache=False):
     # 保持數字相關設定最新
     if hasattr(config, "sync_digit_overrides"):
         config.sync_digit_overrides()
@@ -26,6 +26,19 @@ def generate_text_image(text, font_path=None, size=None, ignore_router=False):
     """
     給定文字與字體路徑，回傳 PIL.Image。
     此版本包含智慧分派邏輯。
+
+    Parameters
+    ----------
+    text : str
+        要渲染的文字
+    font_path : str, optional
+        字體檔路徑，預設為 ``config.FONT_PATH``
+    size : int, optional
+        圖片尺寸，預設為 ``config.IMAGE_SIZE``
+    ignore_router : bool, optional
+        不使用字元路由表時設為 ``True``
+    clear_cache : bool, optional
+        渲染後是否清除字型快取
     """
     images = []
     spacings = []
@@ -80,6 +93,9 @@ def generate_text_image(text, font_path=None, size=None, ignore_router=False):
         canvas.paste(im, (x, y_offset), im)
         if i < len(spacings) -1:
             x += im.width + spacings[i]
+
+    if clear_cache:
+        _load_font.cache_clear()
 
     return canvas
 

--- a/extractor.py
+++ b/extractor.py
@@ -1,6 +1,14 @@
 from fontTools.ttLib import TTFont
 from fontTools.pens.basePen import BasePen
 from fontTools.pens.transformPen import TransformPen
+from functools import lru_cache
+import os
+
+
+@lru_cache(maxsize=16)
+def _load_font(path: str) -> TTFont:
+    path = os.path.abspath(os.path.normcase(path))
+    return TTFont(path)
 
 
 class PointListPen(BasePen):
@@ -18,7 +26,7 @@ class PointListPen(BasePen):
         self.current_path.append(pt)
 
     def _curveToOne(self, pt1, pt2, pt3):
-        steps = 10
+        steps = 20
         last = self._getCurrentPoint()
         for i in range(1, steps + 1):
             t = i / steps
@@ -37,7 +45,7 @@ class PointListPen(BasePen):
 
 
 def extract_paths(font_path, char):
-    font = TTFont(font_path)
+    font = _load_font(font_path)
     glyphSet = font.getGlyphSet()
     cmap = font.getBestCmap()
     glyph_name = cmap.get(ord(char))


### PR DESCRIPTION
## Summary
- add LRU cached `_load_font` helper
- use cached fonts in `extract_paths`
- allow clearing font cache from `generate_text_image`
- bump curve sampling resolution for smoother paths

## Testing
- `pip install -r requirements.txt`
- `python demo.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6870aa102e80832b9e1e0cd5d284d3ce