### PR TITLE
Improve install scripts to register package

### DIFF
--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -12,7 +12,7 @@
    - 維持標準套件結構，視需要補充 `setup.py` 以相容舊版工具。
    - 保持 `python -m Make_report_sign_easy` 或直接 `import Make_report_sign_easy` 的使用方式。
 2. **一鍵安裝與自動更新**
-   - 提供 `setup.sh` 及 `install.bat`，可一次安裝依賴並啟動主程式。
+   - 提供 `setup.sh` 及 `install.bat`，可一次安裝依賴與套件並啟動主程式。
    - `auto_update.py` 會在 CLI/GUI 啟動時檢查 GitHub 版本並提示升級。
 3. **PyInstaller 打包**
    - 編寫程式時避免依賴特定安裝工具，以利打包。
@@ -33,7 +33,7 @@
   python -m Make_report_sign_easy
   ```
 - 一般用戶：
-  下載並執行 `install.bat`（或 `setup.sh`）以安裝依賴並啟動主程式。
+  下載並執行 `install.bat`（或 `setup.sh`）以安裝依賴和本套件，並啟動主程式。
 - 未來亦可提供 PyInstaller 打包版，單檔執行並包含自動更新機制。
 
 ## 五、總結

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ pip install pillow fonttools
 # 下載本專案
 git clone https://github.com/AustinHongLee/Make_report_sign_easy.git
 cd Make_report_sign_easy
-bash setup.sh  # 安裝相依套件 (Linux/macOS)
-install.bat    # Windows 用戶
+bash setup.sh  # 安裝依賴並安裝套件 (Linux/macOS)
+install.bat    # Windows 用戶，自動安裝依賴與套件
 ```
 
 ## 快速使用 Quick Start
@@ -107,7 +107,7 @@ If a new release is found, a reminder message will be shown.
 專案隨附基本的 `pytest` 測試，可透過下列指令執行：
 
 ```bash
-bash setup.sh  # 或直接安裝需求套件
+bash setup.sh  # 安裝依賴與套件後執行測試
 pytest
 ```
 

--- a/install.bat
+++ b/install.bat
@@ -5,6 +5,7 @@ SET SCRIPT_DIR=%~dp0
 cd /d %SCRIPT_DIR%
 
 python -m pip install -r requirements.txt
+python -m pip install -e .
 
 if not exist previews mkdir previews
 

--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
 python -m pip install -r requirements.txt
+python -m pip install -e .
 mkdir -p previews confirm
 echo "Dependencies installed."
 python demo.py "$@"


### PR DESCRIPTION
## Summary
- install the package in `install.bat`
- install the package in `setup.sh`
- document that install scripts install dependencies and the package
- update development guide about the install scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885ea1d9e60832b992735c01303393f